### PR TITLE
feat: matchup mode — offense vs defense on one field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ComparePage } from '@/features/compare/ComparePage';
 import { GeometryLabPage } from '@/features/geometry-lab/GeometryLabPage';
 import { PrimerPage } from '@/components/PrimerPage';
 import { GlossaryPage } from '@/components/GlossaryPage';
+import { MatchupPage } from '@/features/matchup/MatchupPage';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useUserStore } from '@/stores/userStore';
@@ -50,6 +51,7 @@ export function App() {
             <Route path="/geometry-lab" element={<GeometryLabPage />} />
             <Route path="/primer" element={<PrimerPage />} />
             <Route path="/glossary" element={<GlossaryPage />} />
+            <Route path="/matchup" element={<MatchupPage />} />
           </Route>
         </Routes>
       </ErrorBoundary>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -108,6 +108,7 @@ export function HomePage() {
         <nav className="home-nav">
           <Link to="/compare" className="home-nav-link">Compare</Link>
           <Link to="/geometry-lab" className="home-nav-link">Geometry Lab</Link>
+          <Link to="/matchup" className="home-nav-link">Matchup</Link>
           <Link to="/primer" className="home-nav-link home-nav-primer">Football 101</Link>
           <Link to="/glossary" className="home-nav-link">Glossary</Link>
           {user ? (

--- a/src/features/matchup/MatchupPage.css
+++ b/src/features/matchup/MatchupPage.css
@@ -1,0 +1,292 @@
+/* ═══════════════════════════════════════════════════════════════
+   Matchup Mode — Offense vs Defense on one field
+═══════════════════════════════════════════════════════════════ */
+
+.matchup-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* ─── Header ───────────────────────────────────────────────── */
+
+.matchup-header {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid rgba(26, 45, 77, 0.6);
+  background: rgba(10, 18, 36, 0.7);
+  backdrop-filter: blur(8px);
+}
+
+.matchup-back {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-cyan-dim);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.matchup-back:hover {
+  color: var(--color-cyan);
+}
+
+.matchup-title {
+  font-family: 'Orbitron', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.matchup-subtitle {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+/* ─── Selectors ────────────────────────────────────────────── */
+
+.matchup-selectors {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 24px;
+  border-bottom: 1px solid rgba(26, 45, 77, 0.4);
+}
+
+.matchup-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.matchup-selector-label {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.matchup-label-offense {
+  color: var(--color-cyan);
+}
+
+.matchup-label-defense {
+  color: #ef4444;
+}
+
+.matchup-selector-select {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  color: var(--color-text-primary);
+  background: rgba(10, 18, 36, 0.8);
+  border: 1px solid rgba(26, 45, 77, 0.8);
+  padding: 8px 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.matchup-selector-select:focus {
+  outline: none;
+  border-color: var(--color-cyan);
+}
+
+.matchup-vs {
+  font-family: 'Orbitron', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-amber);
+  flex-shrink: 0;
+}
+
+/* ─── Field ────────────────────────────────────────────────── */
+
+.matchup-field-wrap {
+  flex: 1;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.matchup-field-wrap svg {
+  width: 100%;
+  max-height: calc(100vh - 320px);
+  height: auto;
+}
+
+.matchup-loading,
+.matchup-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 0;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+}
+
+/* ─── Playback Controls ───────────────────────────────────── */
+
+.matchup-playback {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-top: 1px solid rgba(26, 45, 77, 0.4);
+  background: rgba(10, 18, 36, 0.5);
+}
+
+.matchup-pb-btn {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid rgba(26, 45, 77, 0.6);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.matchup-pb-btn:hover:not(:disabled) {
+  color: var(--color-cyan);
+  border-color: var(--color-cyan);
+}
+
+.matchup-pb-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.matchup-pb-play {
+  color: var(--color-amber);
+  border-color: rgba(255, 184, 0, 0.4);
+}
+
+.matchup-pb-play:hover {
+  color: var(--color-amber);
+  border-color: var(--color-amber);
+  background: rgba(255, 184, 0, 0.06);
+}
+
+.matchup-pb-phase {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-left: 8px;
+}
+
+.matchup-pb-speed {
+  display: flex;
+  gap: 0;
+  margin-left: auto;
+}
+
+.matchup-speed-btn {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid rgba(26, 45, 77, 0.6);
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.matchup-speed-btn + .matchup-speed-btn {
+  border-left: none;
+}
+
+.matchup-speed-btn.active {
+  color: var(--color-cyan);
+  border-color: var(--color-cyan);
+  background: rgba(0, 229, 255, 0.06);
+}
+
+/* ─── Phase Info ───────────────────────────────────────────── */
+
+.matchup-phase-info {
+  display: flex;
+  gap: 16px;
+  padding: 12px 24px 20px;
+}
+
+.matchup-phase-desc {
+  flex: 1;
+  border: 1px solid rgba(26, 45, 77, 0.4);
+  padding: 12px 14px;
+}
+
+.matchup-phase-desc p {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  margin: 4px 0 0;
+}
+
+.matchup-phase-label {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.matchup-phase-offense .matchup-phase-label {
+  color: var(--color-cyan);
+}
+
+.matchup-phase-offense {
+  border-color: rgba(0, 229, 255, 0.2);
+}
+
+.matchup-phase-defense .matchup-phase-label {
+  color: #ef4444;
+}
+
+.matchup-phase-defense {
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+/* ─── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .matchup-selectors {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .matchup-selector {
+    width: 100%;
+  }
+
+  .matchup-vs {
+    display: none;
+  }
+
+  .matchup-playback {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .matchup-phase-info {
+    flex-direction: column;
+  }
+
+  .matchup-header {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}

--- a/src/features/matchup/MatchupPage.tsx
+++ b/src/features/matchup/MatchupPage.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { listConcepts, getConcept } from '@/api/concepts';
+import { FootballField } from '@/components/field/FootballField';
+import { PlayerToken } from '@/components/field/PlayerToken';
+import { MotionPathRenderer, PathArrowDefs } from '@/components/field/MotionPathRenderer';
+import { ZoneOverlayComponent } from '@/components/field/ZoneOverlay';
+import { AnnotationComponent } from '@/components/field/Annotation';
+import { BallToken } from '@/components/field/BallToken';
+import { AiSidebar } from '@/components/ai';
+import type { Concept, ConceptSummary, Phase, Vector2D } from '@/types';
+import './MatchupPage.css';
+
+const OFFENSE_CATEGORIES = ['formation-offense', 'route-concept'];
+const DEFENSE_CATEGORIES = ['formation-defense', 'coverage', 'blitz'];
+
+function resolvePositions(phases: Phase[], index: number): Map<string, Vector2D> {
+  const positions = new Map<string, Vector2D>();
+  for (let i = 0; i <= index; i++) {
+    for (const ps of phases[i].players) {
+      positions.set(ps.playerId, ps.position);
+    }
+  }
+  return positions;
+}
+
+export function MatchupPage() {
+  const [concepts, setConcepts] = useState<ConceptSummary[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+
+  const [offense, setOffense] = useState<Concept | null>(null);
+  const [defense, setDefense] = useState<Concept | null>(null);
+  const [loadingO, setLoadingO] = useState(false);
+  const [loadingD, setLoadingD] = useState(false);
+
+  // Playback state (local, not shared with other pages)
+  const [currentPhase, setCurrentPhase] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+
+  useEffect(() => {
+    listConcepts({ sort: 'alpha' })
+      .then((res) => setConcepts(res.data))
+      .catch(() => {})
+      .finally(() => setCatalogLoading(false));
+  }, []);
+
+  const offenseConcepts = useMemo(
+    () => concepts.filter((c) => OFFENSE_CATEGORIES.includes(c.category)),
+    [concepts],
+  );
+  const defenseConcepts = useMemo(
+    () => concepts.filter((c) => DEFENSE_CATEGORIES.includes(c.category)),
+    [concepts],
+  );
+
+  const handleSelectOffense = useCallback((slug: string) => {
+    if (!slug) { setOffense(null); return; }
+    setLoadingO(true);
+    setCurrentPhase(0);
+    setIsPlaying(false);
+    getConcept(slug)
+      .then(setOffense)
+      .catch(() => setOffense(null))
+      .finally(() => setLoadingO(false));
+  }, []);
+
+  const handleSelectDefense = useCallback((slug: string) => {
+    if (!slug) { setDefense(null); return; }
+    setLoadingD(true);
+    setCurrentPhase(0);
+    setIsPlaying(false);
+    getConcept(slug)
+      .then(setDefense)
+      .catch(() => setDefense(null))
+      .finally(() => setLoadingD(false));
+  }, []);
+
+  // Phase count = max of both concepts
+  const totalPhases = Math.max(
+    offense?.phases.length ?? 0,
+    defense?.phases.length ?? 0,
+  );
+
+  // Auto-advance
+  useEffect(() => {
+    if (!isPlaying || totalPhases === 0) return;
+
+    const offPhase = offense?.phases[Math.min(currentPhase, (offense?.phases.length ?? 1) - 1)];
+    const defPhase = defense?.phases[Math.min(currentPhase, (defense?.phases.length ?? 1) - 1)];
+    const duration = Math.max(offPhase?.durationMs ?? 1000, defPhase?.durationMs ?? 1000) / speed;
+
+    const timer = setTimeout(() => {
+      if (currentPhase < totalPhases - 1) {
+        setCurrentPhase((p) => p + 1);
+      } else {
+        setIsPlaying(false);
+      }
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [isPlaying, currentPhase, totalPhases, speed, offense, defense]);
+
+  const conceptSlugs = useMemo(() => {
+    const slugs: string[] = [];
+    if (offense) slugs.push(offense.slug);
+    if (defense) slugs.push(defense.slug);
+    return slugs;
+  }, [offense, defense]);
+
+  // Resolve positions for both sides
+  const offPhaseIdx = offense ? Math.min(currentPhase, offense.phases.length - 1) : 0;
+  const defPhaseIdx = defense ? Math.min(currentPhase, defense.phases.length - 1) : 0;
+
+  const offPositions = offense ? resolvePositions(offense.phases, offPhaseIdx) : new Map();
+  const defPositions = defense ? resolvePositions(defense.phases, defPhaseIdx) : new Map();
+
+  const offRosterMap = useMemo(() => new Map(offense?.roster.map((p) => [p.id, p]) ?? []), [offense]);
+  const defRosterMap = useMemo(() => new Map(defense?.roster.map((p) => [p.id, p]) ?? []), [defense]);
+
+  const offPhase = offense?.phases[offPhaseIdx];
+  const defPhase = defense?.phases[defPhaseIdx];
+  const transitionDuration = (() => {
+    const d = Math.max(offPhase?.durationMs ?? 1000, defPhase?.durationMs ?? 1000);
+    return (d / 1000) / speed;
+  })();
+
+  return (
+    <div className="matchup-container">
+      {/* Header */}
+      <header className="matchup-header">
+        <Link to="/" className="matchup-back">&larr; Library</Link>
+        <h1 className="matchup-title">Matchup</h1>
+        <span className="matchup-subtitle">Offense vs Defense on one field</span>
+      </header>
+
+      {/* Selectors */}
+      <div className="matchup-selectors">
+        <div className="matchup-selector">
+          <label className="matchup-selector-label matchup-label-offense">Offense</label>
+          <select
+            className="matchup-selector-select"
+            value={offense?.slug ?? ''}
+            onChange={(e) => handleSelectOffense(e.target.value)}
+            disabled={catalogLoading}
+          >
+            <option value="">— Choose offense —</option>
+            {offenseConcepts.map((c) => (
+              <option key={c.slug} value={c.slug}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="matchup-vs">VS</div>
+
+        <div className="matchup-selector">
+          <label className="matchup-selector-label matchup-label-defense">Defense</label>
+          <select
+            className="matchup-selector-select"
+            value={defense?.slug ?? ''}
+            onChange={(e) => handleSelectDefense(e.target.value)}
+            disabled={catalogLoading}
+          >
+            <option value="">— Choose defense —</option>
+            {defenseConcepts.map((c) => (
+              <option key={c.slug} value={c.slug}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Field */}
+      <div className="matchup-field-wrap">
+        {(loadingO || loadingD) && (
+          <div className="matchup-loading">Loading...</div>
+        )}
+
+        {!loadingO && !loadingD && !offense && !defense && (
+          <div className="matchup-empty">Select an offense and defense to see them face off</div>
+        )}
+
+        {(offense || defense) && !loadingO && !loadingD && (
+          <FootballField>
+            <defs>
+              <PathArrowDefs />
+            </defs>
+
+            {/* Line of scrimmage */}
+            <line x1={600} y1={0} x2={600} y2={533} stroke="var(--color-cyan)" strokeWidth="1.5" opacity="0.25" strokeDasharray="8 4" />
+
+            {/* Side labels */}
+            {offense && (
+              <text x={530} y={16} fill="var(--color-cyan)" fontSize="9" fontFamily="monospace" textAnchor="middle" opacity="0.5" fontWeight="bold">
+                {offense.label.toUpperCase()} →
+              </text>
+            )}
+            {defense && (
+              <text x={680} y={16} fill="rgba(239,68,68,0.5)" fontSize="9" fontFamily="monospace" textAnchor="middle" fontWeight="bold">
+                ← {defense.label.toUpperCase()}
+              </text>
+            )}
+
+            {/* Offense overlays */}
+            {offPhase?.overlays?.filter((o) => o.type === 'zone').map((o) => (
+              <ZoneOverlayComponent key={`off-${o.id}`} overlay={o} />
+            ))}
+
+            {/* Defense overlays */}
+            {defPhase?.overlays?.filter((o) => o.type === 'zone').map((o) => (
+              <ZoneOverlayComponent key={`def-${o.id}`} overlay={o} />
+            ))}
+
+            {/* Offense motion paths */}
+            {offPhase?.players.map((ps) =>
+              ps.paths?.map((path, pi) => (
+                <MotionPathRenderer
+                  key={`off-${ps.playerId}-path-${pi}`}
+                  path={path}
+                  animated={currentPhase > 0}
+                />
+              )),
+            )}
+
+            {/* Defense motion paths */}
+            {defPhase?.players.map((ps) =>
+              ps.paths?.map((path, pi) => (
+                <MotionPathRenderer
+                  key={`def-${ps.playerId}-path-${pi}`}
+                  path={path}
+                  animated={currentPhase > 0}
+                />
+              )),
+            )}
+
+            {/* Ball */}
+            {offPhase?.ball && (
+              <motion.g
+                animate={{ x: offPhase.ball.position.x, y: offPhase.ball.position.y }}
+                initial={false}
+                transition={{ duration: transitionDuration, ease: 'easeInOut' }}
+              >
+                <BallToken ball={{ ...offPhase.ball, position: { x: 0, y: 0 } }} />
+              </motion.g>
+            )}
+
+            {/* Offense tokens */}
+            {Array.from(offPositions.entries()).map(([playerId, pos]) => {
+              const player = offRosterMap.get(playerId);
+              if (!player) return null;
+              const ps = offPhase?.players.find((p) => p.playerId === playerId);
+              return (
+                <motion.g
+                  key={`off-${playerId}`}
+                  animate={{ x: pos.x, y: pos.y }}
+                  initial={false}
+                  transition={{ duration: transitionDuration, ease: 'easeInOut' }}
+                >
+                  <PlayerToken
+                    role={player.role}
+                    position={{ x: 0, y: 0 }}
+                    label={player.label || player.id}
+                    highlighted={ps?.highlighted ?? false}
+                    opacity={ps?.opacity ?? 1}
+                  />
+                </motion.g>
+              );
+            })}
+
+            {/* Defense tokens */}
+            {Array.from(defPositions.entries()).map(([playerId, pos]) => {
+              const player = defRosterMap.get(playerId);
+              if (!player) return null;
+              const ps = defPhase?.players.find((p) => p.playerId === playerId);
+              return (
+                <motion.g
+                  key={`def-${playerId}`}
+                  animate={{ x: pos.x, y: pos.y }}
+                  initial={false}
+                  transition={{ duration: transitionDuration, ease: 'easeInOut' }}
+                >
+                  <PlayerToken
+                    role={player.role}
+                    position={{ x: 0, y: 0 }}
+                    label={player.label || player.id}
+                    highlighted={ps?.highlighted ?? false}
+                    opacity={ps?.opacity ?? 1}
+                  />
+                </motion.g>
+              );
+            })}
+
+            {/* Annotations from both */}
+            {offPhase?.annotations?.map((a) => (
+              <AnnotationComponent key={`off-${a.id}`} annotation={a} />
+            ))}
+            {defPhase?.annotations?.map((a) => (
+              <AnnotationComponent key={`def-${a.id}`} annotation={a} />
+            ))}
+          </FootballField>
+        )}
+      </div>
+
+      {/* Playback controls */}
+      {totalPhases > 0 && (
+        <div className="matchup-playback">
+          <button
+            className="matchup-pb-btn"
+            onClick={() => setCurrentPhase(Math.max(0, currentPhase - 1))}
+            disabled={currentPhase === 0}
+          >
+            ◀ Prev
+          </button>
+          <button
+            className="matchup-pb-btn matchup-pb-play"
+            onClick={() => setIsPlaying(!isPlaying)}
+          >
+            {isPlaying ? '⏸ Pause' : '▶ Play'}
+          </button>
+          <button
+            className="matchup-pb-btn"
+            onClick={() => setCurrentPhase(Math.min(totalPhases - 1, currentPhase + 1))}
+            disabled={currentPhase >= totalPhases - 1}
+          >
+            Next ▶
+          </button>
+          <span className="matchup-pb-phase">
+            Phase {currentPhase + 1} / {totalPhases}
+          </span>
+          <div className="matchup-pb-speed">
+            {[0.5, 1, 2].map((s) => (
+              <button
+                key={s}
+                className={`matchup-speed-btn ${speed === s ? 'active' : ''}`}
+                onClick={() => setSpeed(s)}
+              >
+                {s}x
+              </button>
+            ))}
+          </div>
+          <button
+            className="matchup-pb-btn"
+            onClick={() => { setCurrentPhase(0); setIsPlaying(false); }}
+          >
+            ⟲ Reset
+          </button>
+        </div>
+      )}
+
+      {/* Phase descriptions */}
+      {(offense || defense) && !loadingO && !loadingD && (
+        <div className="matchup-phase-info">
+          {offense && offPhase && (
+            <div className="matchup-phase-desc matchup-phase-offense">
+              <span className="matchup-phase-label">Offense — {offPhase.label}</span>
+              <p>{offPhase.description}</p>
+            </div>
+          )}
+          {defense && defPhase && (
+            <div className="matchup-phase-desc matchup-phase-defense">
+              <span className="matchup-phase-label">Defense — {defPhase.label}</span>
+              <p>{defPhase.description}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* AI Assistant */}
+      {conceptSlugs.length > 0 && (
+        <AiSidebar conceptSlugs={conceptSlugs} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/matchup` page that overlays an offense concept and a defense concept on the same SVG field
- Separate dropdowns filtered by category (offense vs defense concepts)
- Shared playback controls with play/pause, prev/next, speed selector, and reset
- Phase descriptions for both sides shown below the field
- AI sidebar with both concept slugs for combined tactical analysis
- Nav link added to library homepage
- Responsive layout for mobile

## Test plan
- [x] Navigate to /matchup from homepage nav
- [x] Select an offense formation and a defense coverage
- [x] Verify both rosters render on the same field with correct token shapes/colors
- [x] Test playback controls (play, pause, step, speed, reset)
- [x] Verify phase descriptions update for both sides
- [x] Test with only offense or only defense selected
- [x] Test responsive layout on mobile viewport